### PR TITLE
Allow Symfony 5.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     ],
     "license": "MIT",
     "require": {
-        "php": "^7.2",
+        "php": ">=7.2",
         "doctrine/doctrine-bundle": "^1.0 || ^2.0",
         "setono/doctrine-orm-batcher": "^0.6",
         "symfony/config": "^4.0 || ^5.0",

--- a/composer.json
+++ b/composer.json
@@ -12,9 +12,9 @@
         "php": ">=7.2",
         "doctrine/doctrine-bundle": "^1.0 || ^2.0",
         "setono/doctrine-orm-batcher": "^0.6",
-        "symfony/config": "^4.0 || ^5.0",
-        "symfony/dependency-injection": "^4.0 || ^5.0",
-        "symfony/framework-bundle": "^4.0 || ^5.0"
+        "symfony/config": "^4.4 || ^5.0",
+        "symfony/dependency-injection": "^4.4 || ^5.0",
+        "symfony/framework-bundle": "^4.4 || ^5.0"
     },
     "require-dev": {
         "localheinz/composer-normalize": "^1.1",

--- a/composer.json
+++ b/composer.json
@@ -12,9 +12,9 @@
         "php": "^7.2",
         "doctrine/doctrine-bundle": "^1.0 || ^2.0",
         "setono/doctrine-orm-batcher": "^0.6",
-        "symfony/config": "^4.0",
-        "symfony/dependency-injection": "^4.0",
-        "symfony/framework-bundle": "^4.0"
+        "symfony/config": "^4.0 || ^5.0",
+        "symfony/dependency-injection": "^4.0 || ^5.0",
+        "symfony/framework-bundle": "^4.0 || ^5.0"
     },
     "require-dev": {
         "localheinz/composer-normalize": "^1.1",


### PR DESCRIPTION
I didn't test anything. But allowing is the first step to go further :) .

And it should not have any issue.

Issues on CI not related. Tests passing.

Please notice this is blocking `setono/sylius-feed-plugin` to be compatible with Symfony 5.x.

updated: it should be compatible with php8 as well